### PR TITLE
Fix timeout

### DIFF
--- a/cmd/linebot/main.go
+++ b/cmd/linebot/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io"
 	"log"
 	"net/http"
 	"os"
@@ -32,13 +31,6 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	// health check endpoint
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		//nolint:errcheck
-		io.WriteString(w, "healthy")
-	})
-	// line webhook endpoint
 	mux.HandleFunc("/line_callback", func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Request received")
 

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -18,7 +18,7 @@ resource "google_cloud_run_service" "linebot" {
     spec {
       service_account_name = google_service_account.linebot.email
 
-      timeout_seconds = 10
+      timeout_seconds = 60
       containers {
         image = local.image
 


### PR DESCRIPTION
- Health check endpoint は不要なので削除 (revert: fa022b848ae3d7723a4bc9321911d296e7b8411d)
- timeout が厳しすぎて health check に間に合わないため延長