### PR TITLE
ci: fix terraform workflow

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -112,6 +112,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
   terraform:
+    if: github.actor != 'dependabot[bot]'
     name: Terraform
     defaults:
       run:


### PR DESCRIPTION
dependabot の PR では Secrets が読み取れず、一部 job が失敗するため dependabot の PR では実行しないように修正する。