### PR TITLE
chore: reduce memory allocation

### DIFF
--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -25,7 +25,7 @@ resource "google_cloud_run_service" "linebot" {
         resources {
           limits = {
             cpu    = "1000m"
-            memory = "640Mi"
+            memory = "300Mi"
           }
         }
 


### PR DESCRIPTION
- #48 によりメモリ使用量が減ったため、割当量を見直す。
![image](https://user-images.githubusercontent.com/695166/136444068-56d47d98-d1f9-4271-a673-50df70d832c9.png)
