### PR TITLE
chore: add GOMAXPROCS log

### DIFF
--- a/cmd/linebot/main.go
+++ b/cmd/linebot/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -77,7 +78,7 @@ func main() {
 		Handler: handler(bot),
 		Addr:    addr,
 	}
-	bot.Log.Info("start server")
+	bot.Log.Info("start server", zap.Int("GOMAXPROCS", runtime.GOMAXPROCS(0)))
 	//nolint:errcheck
 	go srv.ListenAndServe()
 


### PR DESCRIPTION
GOMAXPROCS の値が割り当てている CPU の core 数を上回る場合は、[go.uber.org/automaxprocs](https://github.com/uber-go/automaxprocs) を導入する。
まずはログを仕込む。