### PR TITLE
fix(bot): check delete item length

### DIFF
--- a/bot/shopping.go
+++ b/bot/shopping.go
@@ -269,6 +269,9 @@ func (s *ShoppingService) deleteFromItem(ctx context.Context, conversationID mod
 			ret = append(ret, item)
 			ids = append(ids, item.ID)
 		}
+		if len(ids) == 0 {
+			return ret, nil
+		}
 		if err := s.shopping.DeleteItems(ctx, conversationID, ids); err != nil {
 			return nil, xerrors.Errorf("failed to delete shopping items: %w", err)
 		}


### PR DESCRIPTION
存在しない index を指定して shopping item の削除を試みた際のハンドリングを追加。

![image](https://user-images.githubusercontent.com/695166/136642715-f4affd9f-1e26-4332-adf5-a9284356dab4.png)
