### PR TITLE
fix(cmd/linebot): fix tracer shutdown context timeout

### DIFF
--- a/cmd/linebot/main.go
+++ b/cmd/linebot/main.go
@@ -58,9 +58,9 @@ func main() {
 			bot.log.Error("failed to initialize tracer", zap.Error(err))
 		}
 		defer func() {
-			tpShutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 			defer cancel()
-			if err := tp.Shutdown(tpShutdownCtx); err != nil {
+			if err := tp.Shutdown(ctx); err != nil {
 				bot.log.Error("failed to shutdown tracer", zap.Error(err))
 			}
 		}()


### PR DESCRIPTION
tracer shutdown timeout を 5s => 10s に延長する。
- fix #56