### PR TITLE
Fix message handling

### DIFF
--- a/domain/model/item.go
+++ b/domain/model/item.go
@@ -12,3 +12,15 @@ type Item struct {
 	Name    []string
 	Action  ActionType
 }
+
+func (i *Item) UniqueIndexes() []int {
+	indexes := make([]int, 0)
+	set := make(map[int]struct{}, len(i.Indexes))
+	for _, index := range i.Indexes {
+		if _, ok := set[index]; !ok {
+			indexes = append(indexes, index)
+			set[index] = struct{}{}
+		}
+	}
+	return indexes
+}

--- a/domain/model/item_test.go
+++ b/domain/model/item_test.go
@@ -1,0 +1,54 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestItem_UniqueIndexes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		item *Item
+		want []int
+	}{
+		{
+			name: "nil indexes",
+			item: &Item{
+				Indexes: nil,
+			},
+			want: []int{},
+		},
+		{
+			name: "empty indexes",
+			item: &Item{
+				Indexes: []int{},
+			},
+			want: []int{},
+		},
+		{
+			name: "sequential indexes",
+			item: &Item{
+				Indexes: []int{1, 2, 3},
+			},
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "duplicate indexes",
+			item: &Item{
+				Indexes: []int{1, 1, 2, 3, 3, 5},
+			},
+			want: []int{1, 2, 3, 5},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.item.UniqueIndexes()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got: %+v, want: %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/presentation/http/handler.go
+++ b/presentation/http/handler.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator"
@@ -72,6 +73,10 @@ func (h *Handler) lineCallback() func(w http.ResponseWriter, r *http.Request) {
 
 		if err := h.eventHandler.Handle(ctx, events); err != nil {
 			cl.Error("failed to handle events", zap.Error(err))
+
+			// DEBUG
+			cl.Warn("DEBUG", zap.String("errTest", fmt.Sprintf("%+v", err)))
+
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
## Summary
次の不具合を修正。
- キーワード(`削除`, `除去`)がメッセージに含まれる場合に数字が含まれていないとエラーになる不具合
- 同じ数字が連続する場合にエラーになる不具合を修正。

- #55

## Details
- "削除" とだけ入力された場合の不具合を修正。
- "2, 2を削除" というように、同じ数字が含まれる場合にエラーが発生するため、重複を排除する実装を追加。
- エラーのログ出力を確認するためにログを追加。

## TODO
- 0 という数字が含まれている場合のケースは、エラー発生時のログの動作確認用にあえて残す。