### PR TITLE
fix: fix Cloud Trace Exporter initialization

### DIFF
--- a/cmd/linebot/wire_gen.go
+++ b/cmd/linebot/wire_gen.go
@@ -43,10 +43,7 @@ func register(contextContext context.Context) (*bot, func(), error) {
 		return nil, nil, err
 	}
 	tracerConfig := _wireConfigValue
-	spanExporter, err := tracer.NewCloudTraceExporter()
-	if err != nil {
-		return nil, nil, err
-	}
+	spanExporter := tracer.NewCloudTraceExporter()
 	tracerProvider, cleanup := tracer.New(tracerConfig, configConfig, spanExporter)
 	client, err := firestore.New(contextContext, tracerProvider)
 	if err != nil {

--- a/cmd/screenshot/wire_gen.go
+++ b/cmd/screenshot/wire_gen.go
@@ -30,10 +30,7 @@ func register(ctx context.Context) (*server, func(), error) {
 	screenshot := interactor.NewScreenshot(browserBrowser)
 	screenshotHandler := http.NewScreenshotHandler(logger, screenshot)
 	tracerConfig := _wireConfigValue
-	spanExporter, err := tracer.NewCloudTraceExporter()
-	if err != nil {
-		return nil, nil, err
-	}
+	spanExporter := tracer.NewCloudTraceExporter()
 	tracerProvider, cleanup := tracer.New(tracerConfig, configConfig, spanExporter)
 	mainServer := newServer(configConfig, screenshotHandler, tracerProvider)
 	return mainServer, func() {

--- a/infra/external/linebot/linebot.go
+++ b/infra/external/linebot/linebot.go
@@ -28,7 +28,11 @@ type LINEBot struct {
 }
 
 func NewLINEBot(conf repository.Config) (*LINEBot, error) {
-	hc := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	transport := otelhttp.NewTransport(http.DefaultTransport, otelhttp.WithFilter(func(r *http.Request) bool {
+		// ignore health check request
+		return r.URL.Path != "/"
+	}))
+	hc := &http.Client{Transport: transport}
 	cli, err := linebot.New(
 		conf.LINEChannelSecret(),
 		conf.LINEChannelToken(),

--- a/infra/external/weather/weather.go
+++ b/infra/external/weather/weather.go
@@ -49,7 +49,10 @@ func (w *Weather) newTransport(ctx context.Context) (http.RoundTripper, error) {
 		return nil, xerrors.Errorf("failed to create token source: %w", err)
 	}
 
-	transport := otelhttp.NewTransport(http.DefaultTransport)
+	transport := otelhttp.NewTransport(http.DefaultTransport, otelhttp.WithFilter(func(r *http.Request) bool {
+		// ignore health check request
+		return r.URL.Path != "/"
+	}))
 	t, err := htransport.NewTransport(ctx, transport, option.WithTokenSource(ts))
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create idtoken client: %w", err)


### PR DESCRIPTION
Cloud Trace Agent の初期化に失敗した際に起動は失敗させない。