### PR TITLE
feat(terraform): add Data Transfer Service

### DIFF
--- a/terraform/geolite2/geolite2_city_blocks_schema.json
+++ b/terraform/geolite2/geolite2_city_blocks_schema.json
@@ -1,0 +1,52 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "network",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "geoname_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "registered_country_geoname_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "represented_country_geoname_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_anonymous_proxy",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_satellite_provider",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "postal_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "latitude",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "longitude",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "accuracy_radius",
+    "type": "INTEGER"
+  }
+]

--- a/terraform/geolite2/geolite2_city_locations_schema.json
+++ b/terraform/geolite2/geolite2_city_locations_schema.json
@@ -1,0 +1,72 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "geoname_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "continent_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "continent_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "country_iso_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "country_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "subdivision_1_iso_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "subdivision_1_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "subdivision_2_iso_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "subdivision_2_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "city_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "metro_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "time_zone",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_in_european_union",
+    "type": "INTEGER"
+  }
+]

--- a/terraform/geolite2/snapshot_geolite2_city.sql
+++ b/terraform/geolite2/snapshot_geolite2_city.sql
@@ -1,0 +1,17 @@
+-- Snapshot geolite2.GeoLite2-City
+DECLARE snapshot_name STRING;
+DECLARE expiration TIMESTAMP;
+DECLARE query STRING;
+
+SET expiration = TIMESTAMP_ADD(@run_time, INTERVAL 365 DAY);
+SET snapshot_name = CONCAT("`geolite2.GeoLite2_City_", FORMAT_DATETIME('%Y%m%d', @run_date), "`");
+
+SET query = CONCAT(
+  "CREATE SNAPSHOT TABLE IF NOT EXISTS ",
+  snapshot_name,
+  " CLONE `geolite2.GeoLite2_City` OPTIONS(expiration_timestamp = TIMESTAMP '",
+  expiration,
+  "');"
+);
+
+EXECUTE IMMEDIATE query;

--- a/terraform/geolite2/transform_geolite2_city.sql
+++ b/terraform/geolite2/transform_geolite2_city.sql
@@ -1,0 +1,9 @@
+-- Transform geolite2.GeoLite2-City
+SELECT
+  country_iso_code AS country,
+  city_name AS city,
+  NET.IP_FROM_STRING(REGEXP_EXTRACT(network, r'(.*)/')) network,
+  CAST(REGEXP_EXTRACT(network, r'/(.*)') AS INT64) mask
+FROM `geolite2.GeoLite2-City-Blocks`
+JOIN `geolite2.GeoLite2-City-Locations`
+USING(geoname_id)

--- a/terraform/service_account.tf
+++ b/terraform/service_account.tf
@@ -96,3 +96,27 @@ resource "google_storage_bucket_iam_member" "screenshot-storage" {
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.screenshot.email}"
 }
+
+# access-log GSA
+resource "google_service_account" "access-log" {
+  account_id   = "${var.name}-access-log"
+  display_name = "${var.name}-access-log Service Account"
+}
+
+resource "google_bigquery_dataset_iam_member" "access-log" {
+  dataset_id = google_bigquery_dataset.geolite2.dataset_id
+  role       = "roles/bigquery.admin"
+  member     = "serviceAccount:${google_service_account.access-log.email}"
+}
+
+resource "google_storage_bucket_iam_member" "access-log" {
+  bucket = google_storage_bucket.geolite2.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.access-log.email}"
+}
+
+resource "google_project_iam_member" "access-log" {
+  project = var.project
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${google_service_account.access-log.email}"
+}


### PR DESCRIPTION
## Summary

次の構成で構築する。

- GCS に MaxMind GeoLite2 Database (CSV) ファイルを配置
  - 一旦手動で配置
- BigQuery Data Transfer Service を使用して定期的に GCS から BigQuery に Load
- Scheduled Query により定期的に扱いやすい形式に Transform
- Scheduled Query により定期的に Snapshot を作成し、ストレージ効率良く日次のデータにアクセスできるようにする
