### PR TITLE
feat(terraform): add Cloud Run Job to sync MaxMind GeoLite2

### DIFF
--- a/terraform/secret_manager.tf
+++ b/terraform/secret_manager.tf
@@ -31,3 +31,20 @@ resource "google_secret_manager_secret_version" "line-channel-access-token" {
   secret      = google_secret_manager_secret.line-channel-access-token.id
   secret_data = var.line_channel_access_token
 }
+
+resource "google_secret_manager_secret" "maxmind-license-key" {
+  secret_id = "maxmind-license-key"
+
+  labels = {
+    service = var.name
+  }
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "maxmind-license-key" {
+  secret      = google_secret_manager_secret.maxmind-license-key.id
+  secret_data = var.maxmind_license_key
+}

--- a/terraform/service_account.tf
+++ b/terraform/service_account.tf
@@ -130,6 +130,24 @@ resource "google_project_iam_member" "access-log" {
   member  = "serviceAccount:${google_service_account.access-log.email}"
 }
 
+# maxmind GSA
+resource "google_service_account" "maxmind" {
+  account_id   = "${var.name}-maxmind"
+  display_name = "${var.name}-maxmind Service Account"
+}
+
+resource "google_storage_bucket_iam_member" "maxmind-bucket" {
+  bucket = google_storage_bucket.geolite2.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.maxmind.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "maxmind-secret" {
+  secret_id = google_secret_manager_secret.maxmind-license-key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.maxmind.email}"
+}
+
 # BigQuery Connection
 resource "google_bigquery_connection" "geolite2" {
   connection_id = "geolite2"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -69,6 +69,11 @@ variable "service_endpoint" {
   description = "Cloud Run Service Endpoint (https://*.a.run.app)"
 }
 
+variable "maxmind_license_key" {
+  type        = string
+  description = "MaxMind License Key"
+}
+
 locals {
   # OpenTelemetry sampling rate
   linebot_otel_sampling_rate = "1"


### PR DESCRIPTION
## Summary

MaxMind の GeoLite2 Database (CSV) をダウンロードして GCS に展開する Cloud Run Job を追加し、Cloud Scheduler により毎日 01:00 JST に実行するよう設定。
