### PR TITLE
Add Serverless VPC Access connector

### DIFF
--- a/terraform/cloud_run_linebot.tf
+++ b/terraform/cloud_run_linebot.tf
@@ -101,6 +101,10 @@ resource "google_cloud_run_service" "linebot" {
       annotations = {
         "autoscaling.knative.dev/maxScale" = "1"
         "autoscaling.knative.dev/minScale" = "1"
+
+        # set Serverless VPC Access connector to use static ip in egress connection
+        "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.main.name
+        "run.googleapis.com/vpc-access-egress"    = "all-traffic"
       }
 
       labels = {

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,0 +1,52 @@
+resource "google_compute_network" "main" {
+  name                    = "main"
+  description             = "main vpc network"
+  routing_mode            = "GLOBAL"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  for_each      = local.vpc
+  name          = "main-${each.key}"
+  ip_cidr_range = each.value.ip_cidr_range
+  region        = each.value.region
+  network       = google_compute_network.main.id
+}
+
+resource "google_compute_router" "main" {
+  name    = "main"
+  network = google_compute_network.main.id
+  region  = google_compute_subnetwork.subnet["serverless"].region
+}
+
+resource "google_compute_address" "nat-ips" {
+  count  = 2
+  name   = "main-router-nat-ips-${count.index}"
+  region = google_compute_router.main.region
+}
+
+resource "google_compute_router_nat" "main" {
+  name                               = "main"
+  router                             = google_compute_router.main.name
+  region                             = google_compute_router.main.region
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = google_compute_address.nat-ips.*.self_link
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.subnet["serverless"].id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+}
+
+resource "google_vpc_access_connector" "main" {
+  name           = "main"
+  machine_type   = "f1-micro"
+  min_instances  = 2
+  max_instances  = 3
+  min_throughput = 200
+  max_throughput = 300
+  region         = google_compute_subnetwork.subnet["serverless"].region
+  subnet {
+    name = google_compute_subnetwork.subnet["serverless"].name
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -75,4 +75,14 @@ locals {
 
   # Browser timeout
   screenshot_browser_timeout = "90s"
+
+  # VPC
+  vpc = {
+    serverless = {
+      # Every VPC connector requires its own /28 subnet to place connector instances on;
+      # this subnet must not have any other resources on it other than the VPC connector.
+      ip_cidr_range = "10.100.0.0/28"
+      region        = local.location
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Serverless VPC Access connector を追加して、Egress connection で static IP address を使用します。

## References

- Google Cloud Docs
  - https://cloud.google.com/vpc/docs/serverless-vpc-access
  - https://cloud.google.com/run/docs/configuring/static-outbound-ip
  - https://cloud.google.com/run/docs/configuring/connecting-vpc
- Terraform
  - https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat.html
  - https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vpc_access_connector
- Pricing
  - https://cloud.google.com/compute/all-pricing#ipaddress
  - https://cloud.google.com/vpc/pricing#serverless-vpc-pricing
  - https://cloud.google.com/compute/vm-instance-pricing#sharedcore
  - https://cloud.google.com/free/docs/free-cloud-features#free-tier-usage-limits