### PR TITLE
fix(terraform): add roles/artifactregistry.reader

### DIFF
--- a/terraform/service_account.tf
+++ b/terraform/service_account.tf
@@ -163,3 +163,21 @@ resource "google_storage_bucket_iam_member" "geolite2" {
   role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_bigquery_connection.geolite2.cloud_resource[0].service_account_id}"
 }
+
+# GAR
+data "google_artifact_registry_repository" "repo" {
+  location      = local.location
+  repository_id = local.gar_repository
+}
+
+resource "google_artifact_registry_repository_iam_member" "linebot" {
+  for_each = toset([
+    "serviceAccount:${google_service_account.linebot.email}",
+    "serviceAccount:${google_service_account.screenshot.email}",
+  ])
+  project    = data.google_artifact_registry_repository.repo.project
+  location   = data.google_artifact_registry_repository.repo.location
+  repository = data.google_artifact_registry_repository.repo.name
+  role       = "roles/artifactregistry.reader"
+  member     = each.value
+}


### PR DESCRIPTION
## Summary

GAR の repository に対して read 権限が当たっていないことで image pull に失敗しているので、修正します。
(なぜ今まで動いていたのか…)


## Reference

- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam
- https://cloud.google.com/artifact-registry/docs/release-notes
  - 特に関連するリリースノートは無し
