### PR TITLE
Fix GitHub actions workflows

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,12 +9,12 @@ jobs:
       contents: "read"
       pull-requests: "read"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: 14
       - name: Install dependencies
         run: npm install
-      - uses: wagoid/commitlint-github-action@v5
+      - uses: wagoid/commitlint-github-action@v5.3.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,8 +29,8 @@ jobs:
       matrix:
         target: [linebot, screenshot]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/cache@v3.2.3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -41,9 +41,9 @@ jobs:
           dockerfile: docker/${{ matrix.target }}/Dockerfile
           ignore: DL3008
       - name: Setup docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.2.1
       - name: Build docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v3.3.0
         with:
           context: .
           file: docker/${{ matrix.target }}/Dockerfile
@@ -64,21 +64,21 @@ jobs:
       matrix:
         target: [linebot, screenshot]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/cache@v3.2.3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.2.1
       - name: Output docker build params
         id: params
         run: |
@@ -95,7 +95,7 @@ jobs:
           echo "platforms=$platforms" | tee -a "${GITHUB_OUTPUT}"
           echo "version=$version" | tee -a "${GITHUB_OUTPUT}"
       - name: Build and push docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v3.3.0
         with:
           context: .
           file: docker/${{ matrix.target }}/Dockerfile
@@ -133,28 +133,28 @@ jobs:
       matrix:
         target: [linebot, screenshot]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/cache@v3.2.3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Setup docker buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: google-github-actions/auth@v1
+        uses: docker/setup-buildx-action@v2.2.1
+      - uses: google-github-actions/auth@v1.0.0
         id: auth
         with:
           token_format: access_token
           workload_identity_provider: "projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
           service_account: "github-gar@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com"
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v2.1.0
         with:
           registry: ${{ env.GCP_LOCATION }}-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
       - name: Build and push docker image (${{ env.GCP_LOCATION }}-docker.pkg.dev)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v3.3.0
         with:
           context: .
           file: docker/${{ matrix.target }}/Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -166,3 +166,4 @@ jobs:
             VERSION=v${{ inputs.image_tag }}
           tags: |
             ${{ env.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ matrix.target }}:${{ inputs.image_tag }}
+          provenance: false # keep compatibility to run on Cloud Run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2
+      - uses: actions/checkout@v3.3.0
+      - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.6
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,8 +20,8 @@ jobs:
         working-directory: terraform
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2
+      - uses: actions/checkout@v3.3.0
+      - uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.3.6
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,12 +19,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: ${{ inputs.go_version }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.3.1
         with:
           version: ${{ inputs.golangci_lint_version }}
 
@@ -52,14 +52,14 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/cache@v3.2.3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: ${{ inputs.go_version }}
       - name: Test
@@ -71,8 +71,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: ${{ inputs.go_version }}
       - name: Check generated files

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -23,23 +23,23 @@ jobs:
     env:
       GCLOUD_VERSION: "406.0.0"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/cache@v3.2.3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.2.1
       - name: Build and push docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v3.3.0
         with:
           context: .
           file: docker/${{ matrix.target }}/Dockerfile


### PR DESCRIPTION
## Summary

docker/build-push-action で `provenance: false` を指定して、[これまでと同様](https://github.com/ww24/linebot/pull/464#issuecomment-1399494070)に `application/vnd.docker.distribution.manifest.v2+json` という mediaType で image が作成されるようにします。
これにより、生成された container image が Cloud Run (第1世代、第2世代両方) で稼働しない問題が解消される見込みです。

また、GitHub Actions のバージョンを patch version まで明示的に指定し、変更を追えるようにします。

## Reference

- https://github.com/docker/build-push-action/releases/tag/v3.3.0