### PR TITLE
fix(terraform): use auto

### DIFF
--- a/terraform/secret_manager.tf
+++ b/terraform/secret_manager.tf
@@ -6,7 +6,7 @@ resource "google_secret_manager_secret" "line-channel-secret" {
   }
 
   replication {
-    automatic = true
+    auto {}
   }
 }
 
@@ -23,7 +23,7 @@ resource "google_secret_manager_secret" "line-channel-access-token" {
   }
 
   replication {
-    automatic = true
+    auto {}
   }
 }
 
@@ -40,7 +40,7 @@ resource "google_secret_manager_secret" "maxmind-license-key" {
   }
 
   replication {
-    automatic = true
+    auto {}
   }
 }
 


### PR DESCRIPTION
## Summary

Remove deprecated [automatic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret#automatic) argument.