### PR TITLE
fix(logger): use stack_trace field

### DIFF
--- a/logger/core.go
+++ b/logger/core.go
@@ -1,8 +1,6 @@
 package logger
 
 import (
-	"runtime/debug"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -36,7 +34,9 @@ func (c *core) Write(e zapcore.Entry, fields []zapcore.Field) error {
 		if report := newErrorReport(e.Caller); report != nil {
 			fields = append(fields,
 				zap.Object("context", report),
-				zap.String("exception", e.Message+"\n"+string(debug.Stack())),
+				// see: https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-error
+				// see: https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report#ReportedErrorEvent
+				zap.String("stack_trace", e.Message+"\n"+e.Stack),
 			)
 		}
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -40,6 +40,7 @@ func newLogger(w io.Writer, lvl zapcore.LevelEnabler) *Logger {
 	core := newCore(zapcore.NewCore(enc, ws, lvl))
 	opts := []zap.Option{
 		zap.AddCaller(),
+		zap.AddStacktrace(zapcore.ErrorLevel),
 	}
 	logger := zap.New(core, opts...)
 
@@ -118,7 +119,7 @@ func newEncoderConfig() zapcore.EncoderConfig {
 		NameKey:        "logger",
 		CallerKey:      "",
 		MessageKey:     "message",
-		StacktraceKey:  "stacktrace",
+		StacktraceKey:  "",
 		LineEnding:     zapcore.DefaultLineEnding,
 		EncodeLevel:    encodeLevel,
 		EncodeTime:     zapcore.RFC3339NanoTimeEncoder,


### PR DESCRIPTION
## Summary

Use stack_trace field instead of stacktrace field on Error Reporting.